### PR TITLE
Added compatibility with Union type annotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .pytest_cache/
 .vscode/
+.idea/
 __pycache__/
 venv/
 *.pyc

--- a/py_jobject/definitions.py
+++ b/py_jobject/definitions.py
@@ -4,7 +4,7 @@ Type definitions controller module.
 
 from datetime import date, datetime, time
 from decimal import Decimal
-from typing import List
+from typing import List, Union
 
 from .defs import (
     DateDefinition,
@@ -33,6 +33,7 @@ STATIC_TYPE_DEFINITIONS = {
     time: TimeDefinition()
 }
 
+
 def get_type_definition(type_):
     """
     Gets a type definition.
@@ -40,7 +41,15 @@ def get_type_definition(type_):
 
     definition = STATIC_TYPE_DEFINITIONS.get(type_)
     if definition is None:
-        if type_.__name__ == List.__name__:
+
+        if hasattr(type_, '__origin__') and type_.__origin__ is Union:
+            definitions = list()
+            for t in type_.__args__:
+                definitions.append(get_type_definition(t))
+
+            return definitions
+
+        if hasattr(type_, '__name__') and type_.__name__ == List.__name__:
             return ListDefinition(type_.__args__[0])
 
         if hasattr(type_, '__annotations__'):
@@ -49,3 +58,5 @@ def get_type_definition(type_):
         raise UndefinedTypeError(type_)
 
     return definition
+
+

--- a/py_jobject/from_func.py
+++ b/py_jobject/from_func.py
@@ -3,6 +3,8 @@ Functions to convert from dictionaries to objects.
 """
 
 from .definitions import get_type_definition
+from typing import Union
+from warnings import warn
 
 __all__ = [
     'from_dict'
@@ -16,6 +18,16 @@ def from_dict(source, type_):
     definition = get_type_definition(type_)
 
     if source is not None:
-        return definition.from_dict(source)
+        if hasattr(type_, '__origin__') and type_.__origin__ is Union:
+            for d in definition:
+                try:
+                    return d.from_dict(source)
+                except Exception as e:
+                    warn("Error calling from_dict for {content} to {cls}".format(
+                        content=source,
+                        cls=str(d.type_)
+                    ))
+        else:
+            return definition.from_dict(source)
 
     return None

--- a/py_jobject/to_func.py
+++ b/py_jobject/to_func.py
@@ -3,10 +3,13 @@ Functions to convert from objects to dictionaries.
 """
 
 from .definitions import get_type_definition
+from warnings import warn
+from typing import Union
 
 __all__ = [
     'to_dict'
 ]
+
 
 def to_dict(source, type_=None):
     """
@@ -19,6 +22,16 @@ def to_dict(source, type_=None):
     definition = get_type_definition(type_)
 
     if source is not None:
-        return definition.to_dict(source)
+        if hasattr(type_, '__origin__') and type_.__origin__ is Union:
+            for d in definition:
+                try:
+                    return definition.to_dict(source)
+                except Exception as e:
+                    warn("Error calling to_dict from {content} to dict".format(
+                        content=source,
+                        cls=str(d.type_)
+                    ))
+        else:
+            return definition.to_dict(source)
 
     return None


### PR DESCRIPTION
For properties with multiple type annotatios e.g.:
Prop: Union[Object,  List[Object]]
Py-JObject will try to convert data for each type annotation in Union.
When conversion fails, a warning is raised.